### PR TITLE
Add tutorial draft for 'Designing Fair Machine Learning Algorithms (Advanced Level)'

### DIFF
--- a/Designing Fair Machine Learning Algorithms (Advanced Level)/README_fairness.md
+++ b/Designing Fair Machine Learning Algorithms (Advanced Level)/README_fairness.md
@@ -1,0 +1,112 @@
+# Fairness Evaluation and Mitigation in Machine Learning
+
+This repository demonstrates how to evaluate and mitigate unfairness in binary classification models using the [Fairlearn](https://fairlearn.org/) library. The focus is on assessing disparities across sensitive groups (e.g., `SEX`) and applying mitigation strategies such as **postprocessing with `ThresholdOptimizer`** to improve fairness.
+
+## 📌 Key Features
+
+- Evaluate model fairness using:
+  - False Positive Rate (FPR)
+  - False Negative Rate (FNR)
+  - Balanced Accuracy
+- Compute **standard errors** for fairness metrics
+- Visualize group-level disparities with **error bars**
+- Apply **postprocessing mitigation** using `ThresholdOptimizer`
+- Support for `equalized_odds` constraint to balance FPR and FNR across groups
+
+---
+
+## 📁 Project Structure
+
+```
+.
+├── compute_error_metric.py   # Custom error computation for FPR, FNR, balanced accuracy
+├── fairness_metrics.py       # Fairness metric dictionary used in MetricFrame
+├── visualize_metrics.py      # Error bar plot function for group metrics
+├── mitigate_postprocess.py   # ThresholdOptimizer setup and predictions
+├── model_training.py         # Classifier training and test predictions
+├── main_analysis.ipynb       # Jupyter notebook orchestrating full workflow
+└── README.md                 # This file
+```
+
+---
+
+## 📊 Fairness Metrics & Evaluation
+
+Fairness is evaluated using the `MetricFrame` object from Fairlearn:
+
+```python
+metricframe_unmitigated = MetricFrame(
+    metrics=fairness_metrics,
+    y_true=y_test,
+    y_pred=Y_pred,
+    sensitive_features=A_test,
+)
+```
+
+### Reported Metrics:
+- `balanced_accuracy`
+- `false_positive_rate`
+- `false_negative_rate`
+
+Standard errors are computed for uncertainty quantification.
+
+### Visualization:
+Group-level metrics with confidence intervals:
+
+```python
+plot_group_metrics_with_error_bars(
+    metricframe_unmitigated, 
+    "false_positive_rate", 
+    "false_positive_error"
+)
+```
+
+---
+
+## 🛠️ Fairness Mitigation - Postprocessing
+
+We apply **postprocessing** using Fairlearn's `ThresholdOptimizer`:
+
+```python
+postprocess_est = ThresholdOptimizer(
+    estimator=estimator,
+    constraints="equalized_odds",
+    objective="balanced_accuracy_score",
+    prefit=True,
+    predict_method="predict_proba",
+)
+postprocess_est.fit(X=X_train, y=y_train, sensitive_features=A_train)
+postprocess_pred = postprocess_est.predict(X_test, sensitive_features=A_test)
+```
+
+This adjusts group-specific thresholds to optimize performance while reducing disparities.
+
+---
+
+## 🧪 Assumptions
+
+- **FPR and FNR have equal cost** across groups.
+- In production scenarios, you may apply **weighting schemes** to reflect different societal or financial consequences.
+
+---
+
+## 📦 Requirements
+
+- Python 3.7+
+- scikit-learn
+- fairlearn
+- matplotlib
+- numpy
+- pandas
+
+Install dependencies:
+
+```bash
+pip install fairlearn scikit-learn matplotlib numpy pandas
+```
+
+---
+
+## 👩🏾‍🔬 Authors & Acknowledgements
+
+This work builds on the fairness principles outlined in the Fairlearn documentation and academic literature such as [Hardt et al., 2016](https://arxiv.org/abs/1610.02413).

--- a/Designing Fair Machine Learning Algorithms (Advanced Level)/plot_credit_loan_decisions.ipynb
+++ b/Designing Fair Machine Learning Algorithms (Advanced Level)/plot_credit_loan_decisions.ipynb
@@ -1,0 +1,1784 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\n",
+        "Designing Fair Machine Learning Algorithms\n",
+        "====================="
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Credit Loan Decisions\n",
+        "============"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Package Imports\n",
+        "===============\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "import warnings\n",
+        "\n",
+        "import lightgbm as lgb\n",
+        "import matplotlib.pyplot as plt\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "from sklearn.metrics import balanced_accuracy_score, confusion_matrix, roc_auc_score\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "from sklearn.pipeline import Pipeline\n",
+        "from sklearn.preprocessing import StandardScaler\n",
+        "\n",
+        "from fairlearn.metrics import (\n",
+        "    MetricFrame,\n",
+        "    count,\n",
+        "    equalized_odds_difference,\n",
+        "    false_negative_rate,\n",
+        "    false_positive_rate,\n",
+        "    selection_rate,\n",
+        ")\n",
+        "from fairlearn.postprocessing import ThresholdOptimizer\n",
+        "from fairlearn.reductions import EqualizedOdds, ExponentiatedGradient\n",
+        "\n",
+        "warnings.simplefilter(\"ignore\")\n",
+        "\n",
+        "rand_seed = 1234\n",
+        "np.random.seed(rand_seed)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Fairness considerations of credit loan decisions\n",
+        "================================================\n",
+        "\n",
+        "Fairness and credit lending in the US\n",
+        "-------------------------------------\n",
+        "\n",
+        "In 2019, Apple received backlash on social media after its newly\n",
+        "launched *Apple Card* product appeared to offer higher credit limits to\n",
+        "men compared to women `nedlund2019apple`{.interpreted-text\n",
+        "role=\"footcite\"}. In multiple cases, married couples found the husband\n",
+        "received a credit limit that was 10-20x higher than the wife\\'s even\n",
+        "when the couple had joint assets.\n",
+        "\n",
+        "From a regulatory perspective, financial institutions that operate\n",
+        "within the United States are subject to *legal regulations* prohibiting\n",
+        "discrimination on the [basis of race, gender, or other protected\n",
+        "classes]{.title-ref}\n",
+        "`uscode2011title15chapter41subchapteriv`{.interpreted-text\n",
+        "role=\"footcite\"}. With the increasing prevalence of automated\n",
+        "decision-systems in the financial lending space, experts have raised\n",
+        "concerns about whether these systems could exacerabate existing\n",
+        "inequalities in financial lending.\n",
+        "\n",
+        "Although the two concepts are intertwined, algorithmic fairness is not\n",
+        "the same concept as anti-discrimination law. An AI system can comply\n",
+        "with anti-discrimination law while exhibiting fairness-related concerns.\n",
+        "On the other hand, some fairness interventions may be illegal under\n",
+        "anti-discrimination law.\n",
+        ":footcite`Xiang2019legalcompatibility`{.interpreted-text role=\"cts\"}\n",
+        "discuss the compatibilities and disconnects between anti-discrimination\n",
+        "law and algorithmic notions of fairness. In this case study, we focus on\n",
+        "fairness in financial services rather than compliance with financial\n",
+        "anti-discrimination regulations.\n",
+        "\n",
+        "Ernst & Young (EY) case study\n",
+        "=============================\n",
+        "\n",
+        "In this case study, we aim to replicate the work done in a white paper\n",
+        "`dudik2020assessing`{.interpreted-text role=\"footcite\"}, co-authored by\n",
+        "*Microsoft* and *EY*, on mitigating gender-related performance\n",
+        "disparities in financial lending decisions. In their analysis, Microsoft\n",
+        "and EY demonstrated how Fairlearn could be used to measure and mitigate\n",
+        "unfairness in the loan adjudication process.\n",
+        "\n",
+        "Using a dataset of credit loan outcomes (whether an individual defaulted\n",
+        "on a credit loan), we train a fairness-unaware model to predict the\n",
+        "likelihood an individual will default on a given loan. We use the\n",
+        "Fairlearn toolkit for assessing the fairness of our model, according to\n",
+        "several metrics. Finally, we perform two unfairness mitigation\n",
+        "strategies on our model and compare the results to our original model.\n",
+        "\n",
+        "Because the dataset used in the white paper is not publicly available,\n",
+        "we will introduce a semi-synthetic feature into an existing publicly\n",
+        "available dataset to replicate the outcome disparity found in the\n",
+        "original dataset.\n",
+        "\n",
+        "Credit decisions dataset\n",
+        "------------------------\n",
+        "\n",
+        "As mentioned, we will not be able to use the original loans dataset, and\n",
+        "instead will be working with a publicly available dataset of credit card\n",
+        "defaults in Taiwan collected in 2005. This dataset represents binary\n",
+        "credit card default outcomes for 30,000 applicants with information\n",
+        "pertaining to an applicant\\'s payment history and bill statements over a\n",
+        "six-month period from April 2005 to September 2005, as well as\n",
+        "demographic information, such as *sex*, *age*, *marital status*, and\n",
+        "*education level* of the applicant. A full summary of features is\n",
+        "provided below:\n",
+        "\n",
+        "  features                                                                   description\n",
+        "  -------------------------------------------------------------------------- --------------------------------------------\n",
+        "  sex, education, marriage, age                                              demographic features\n",
+        "  pay\\_0, pay\\_2, pay\\_3, pay\\_4, pay\\_5, pay\\_6                             repayment status (ordinal)\n",
+        "  bill\\_amt1, bill\\_amt2, bill\\_amt3, bill\\_amt4, bill\\_amt5, bill\\_amt\\_6   bill statement amount (Taiwan dollars)\n",
+        "  pay\\_amt1, pay\\_amt2, pay\\_amt3, pay\\_amt4, pay\\_amt5, pay\\_amt6           previous statement amount (Taiwan dollars)\n",
+        "  default payment next month                                                 default information (1 = YES, 0 = NO)\n",
+        "\n",
+        "Let\\'s pretend we are a data scientist at a financial institution who is\n",
+        "tasked with developing a classification model to predict whether an\n",
+        "applicant will default on a personal loan. A positive prediction by the\n",
+        "model means the applicant would default on the credit loan. *Defaulting\n",
+        "on a loan* means the client fails to make payments within a 30-day\n",
+        "window, and the lender can take legal actions against the client.\n",
+        "\n",
+        "Although we do not have a dataset of loan default history, we do have\n",
+        "this data set of credit card payment history. We assume customers who\n",
+        "make monthly credit card payments on time are more *creditworthy*, and\n",
+        "thus less likely to default on a personal credit loan.\n",
+        "\n",
+        "**Decision point: task definition**\n",
+        "\n",
+        "-   **Defaulting on a credit card payment** can be viewed as a proxy for\n",
+        "    the fact that an applicant might not be a good candidate for a\n",
+        "    personal loan.\n",
+        "-   Because most customers did not default on their credit card payment,\n",
+        "    we will need to take this class imbalance into account during our\n",
+        "    modeling process.\n",
+        "\n",
+        "As the data is read in-memory, we will change the column `PAY_0` to\n",
+        "`PAY_1` to make the naming more consistent with the naming of the other\n",
+        "columns. In addition, the target variable `default payment next month`\n",
+        "is changed to `default` to reduce verbosity.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "data_url = \"http://archive.ics.uci.edu/ml/machine-learning-databases/00350/default%20of%20credit%20card%20clients.xls\"\n",
+        "dataset = (\n",
+        "    pd.read_excel(io=data_url, header=1)\n",
+        "    .drop(columns=[\"ID\"])\n",
+        "    .rename(columns={\"PAY_0\": \"PAY_1\", \"default payment next month\": \"default\"})\n",
+        ")\n",
+        "\n",
+        "dataset.shape"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "dataset.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "From the dataset description `yeh2009comparisons`{.interpreted-text\n",
+        "role=\"footcite\"}, we see there are three categorical features:\n",
+        "\n",
+        "-   `SEX`: Sex of the applicant (as a binary feature)\n",
+        "-   `EDUCATION`: Highest level of education achieved by the applicant.\n",
+        "-   `MARRIAGE`: Marital status of the applicant.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "categorical_features = [\"SEX\", \"EDUCATION\", \"MARRIAGE\"]\n",
+        "\n",
+        "for col_name in categorical_features:\n",
+        "    dataset[col_name] = dataset[col_name].astype(\"category\")\n",
+        "\n",
+        "Y, A = dataset.loc[:, \"default\"], dataset.loc[:, \"SEX\"]\n",
+        "X = pd.get_dummies(dataset.drop(columns=[\"default\", \"SEX\"]))\n",
+        "\n",
+        "A_str = A.map({1: \"male\", 2: \"female\"})"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Dataset imbalances\n",
+        "==================\n",
+        "\n",
+        "Before we start training a classifier model, we want to explore the\n",
+        "dataset for any characteristics that may lead to fairness-related harms\n",
+        "later on in the modeling process. In particular, we will focus on the\n",
+        "distribution of sensitive feature `SEX` and the target label `default`.\n",
+        "\n",
+        "As part of an exploratory data analysis, let\\'s explore the distribution\n",
+        "of our sensitive feature `SEX`. We see that 60% of loan applicants were\n",
+        "labeled as [female]{.title-ref} and 40% as [male]{.title-ref}, so we do\n",
+        "not need to worry about imbalance in this feature.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "A_str.value_counts(normalize=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Next, let\\'s explore the distribution of the *loan default rate* `Y`. We\n",
+        "see that around 78% of individuals in the dataset do not default on\n",
+        "their credit loan. While the target label does not display extreme\n",
+        "imbalance, we will need to account for this imbalance in our modeling\n",
+        "section. As opposed to the *sensitive feature* `SEX`, an imbalance in\n",
+        "the target label may result in a classifier that over-optimizes for the\n",
+        "majority class. For example, a classifier that predicts an applicant\n",
+        "will not default would achieve an accuracy of 78%, so we will use the\n",
+        "`balanced_accuracy` score as our evaluation metric to counteract the\n",
+        "label imbalance.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "Y.value_counts(normalize=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Add synthetic noise that is related to the outcome and sex\n",
+        "==========================================================\n",
+        "\n",
+        "For the purpose of this case study, we add a synthetic feature\n",
+        "`Interest` that introduces correlation between the `SEX` label of an\n",
+        "applicant and the `default` outcome. The purpose of this feature is to\n",
+        "replicate outcome disparities present in the original dataset. We can\n",
+        "think of this `Interest` feature as the *interest rate* for the\n",
+        "applicant. If the applicant has a history of defaulting on credit card\n",
+        "payments, the bank will lend to the applicant at a higher interest rate.\n",
+        "We also assume because banks have historically lended primarily to men,\n",
+        "there is less uncertainty (or variance) in the *interest rate* for these\n",
+        "applicants.\n",
+        "\n",
+        "To reflect the above reasoning, the `Interest` feature is drawn from a\n",
+        "*Gaussian distribution* with the following criterion:\n",
+        "\n",
+        "-   If *Male*, draw `Interest` from\n",
+        "    $\\mathcal{N}(2 \\cdot \\text{Default}, 1)$\n",
+        "-   If *Female*, draw `Interest` from\n",
+        "    $\\mathcal{N}(2 \\cdot \\text{Default}, 2)$\n",
+        "\n",
+        "This feature is drawn from a *Gaussian distribution* for computational\n",
+        "simplicity.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "X.loc[:, \"Interest\"] = np.random.normal(loc=2 * Y, scale=A)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Check if this will lead to disparity in naive model\n",
+        "===================================================\n",
+        "\n",
+        "Now that we have created our synthetic feature, let\\'s check how this\n",
+        "new feature interacts with our *sensitive\\_feature* `Sex` and our target\n",
+        "label `default`. We see that for both sexes, the `Interest` feature is\n",
+        "higher for individuals who defaulted on their loan.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "fig, (ax_1, ax_2) = plt.subplots(ncols=2, figsize=(10, 4), sharex=True, sharey=True)\n",
+        "X[\"Interest\"][(A == 1) & (Y == 0)].plot(\n",
+        "    kind=\"kde\", label=\"Payment on Time\", ax=ax_1, title=\"INTEREST for Men\"\n",
+        ")\n",
+        "X[\"Interest\"][(A == 1) & (Y == 1)].plot(kind=\"kde\", label=\"Payment Default\", ax=ax_1)\n",
+        "X[\"Interest\"][(A == 2) & (Y == 0)].plot(\n",
+        "    kind=\"kde\",\n",
+        "    label=\"Payment on Time\",\n",
+        "    ax=ax_2,\n",
+        "    legend=True,\n",
+        "    title=\"INTEREST for Women\",\n",
+        ")\n",
+        "X[\"Interest\"][(A == 2) & (Y == 1)].plot(\n",
+        "    kind=\"kde\", label=\"Payment Default\", ax=ax_2, legend=True\n",
+        ").legend(bbox_to_anchor=(1.6, 1))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Training an initial model\n",
+        "=========================\n",
+        "\n",
+        "In this section, we will train a fairness-unaware model on the training\n",
+        "data. However because of the imbalances in the dataset, we will first\n",
+        "resample the training data to produce a new balanced training dataset.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "def resample_training_data(X_train, Y_train, A_train):\n",
+        "    \"\"\"Down-sample the majority class in the training dataset to produce a\n",
+        "    balanced dataset with a 50/50 split in the predictive labels.\n",
+        "\n",
+        "    Parameters:\n",
+        "    X_train: The training split of the features\n",
+        "    Y_train: The training split of the target labels\n",
+        "    A_train: The training split of the sensitive features\n",
+        "\n",
+        "    Returns:\n",
+        "    Tuple of X_train, Y_train, A_train where each dataset has been re-balanced.\n",
+        "    \"\"\"\n",
+        "    negative_ids = Y_train[Y_train == 0].index\n",
+        "    positive_ids = Y_train[Y_train == 1].index\n",
+        "    balanced_ids = positive_ids.union(np.random.choice(a=negative_ids, size=len(positive_ids)))\n",
+        "\n",
+        "    X_train = X_train.loc[balanced_ids, :]\n",
+        "    Y_train = Y_train.loc[balanced_ids]\n",
+        "    A_train = A_train.loc[balanced_ids]\n",
+        "    return X_train, Y_train, A_train"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "X_train, X_test, y_train, y_test, A_train, A_test = train_test_split(\n",
+        "    X, Y, A_str, test_size=0.35, stratify=Y\n",
+        ")\n",
+        "\n",
+        "X_train, y_train, A_train = resample_training_data(X_train, y_train, A_train)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "At this stage, we will train a *gradient-boosted tree classifier* using\n",
+        "the `lightgbm` package on the balanced training dataset. When we\n",
+        "evaluate the model, we will use the unbalanced testing dataset.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "lgb_params = {\n",
+        "    \"objective\": \"binary\",\n",
+        "    \"metric\": \"auc\",\n",
+        "    \"learning_rate\": 0.03,\n",
+        "    \"num_leaves\": 10,\n",
+        "    \"max_depth\": 3,\n",
+        "    \"random_state\": rand_seed,\n",
+        "    \"n_jobs\": 1,\n",
+        "    \"verbose\": -1,\n",
+        "}\n",
+        "\n",
+        "estimator = Pipeline(\n",
+        "    steps=[\n",
+        "        (\"preprocessing\", StandardScaler()),\n",
+        "        (\"classifier\", lgb.LGBMClassifier(**lgb_params)),\n",
+        "    ]\n",
+        ")\n",
+        "\n",
+        "estimator.fit(X_train, y_train)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We compute the *binary predictions* and the *prediction probabilities*\n",
+        "for the testing data points.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "Y_pred_proba = estimator.predict_proba(X_test)[:, 1]\n",
+        "Y_pred = estimator.predict(X_test)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "From the *ROC Score*, we see the model appears to be differentiating\n",
+        "between *true positives* and *false positives* well. This is to be\n",
+        "expected given the `INTEREST` feature provides a strong discriminant\n",
+        "feature for the classification task.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "roc_auc_score(y_test, Y_pred_proba)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Feature Importance of the Unmitigated Classifier\n",
+        "================================================\n",
+        "\n",
+        "As a model validation check, let\\'s explore the feature importances of\n",
+        "our classifier. As expected, our synthetic feature `INTEREST` has the\n",
+        "highest feature importance because it is highly correlated with the\n",
+        "target variable, by construction.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "lgb.plot_importance(\n",
+        "    estimator.named_steps[\"classifier\"],\n",
+        "    height=0.6,\n",
+        "    title=\"Feature Importance\",\n",
+        "    importance_type=\"gain\",\n",
+        "    max_num_features=15,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Fairness assessment of unmitigated model\n",
+        "========================================\n",
+        "\n",
+        "Now that we have trained our initial fairness-unaware model, let\\'s\n",
+        "perform our fairness assessment for this model. When conducting a\n",
+        "fairness assessment, there are three main steps we want to perform:\n",
+        "\n",
+        "1.  Identify who will be harmed.\n",
+        "2.  Identify the types of harms we anticipate.\n",
+        "3.  Define fairness metrics based on the anticipated harms.\n",
+        "\n",
+        "Who will be harmed?\n",
+        "-------------------\n",
+        "\n",
+        "Based on the incident with *Apple* credit card mentioned at the\n",
+        "beginning of this notebook, we believe the model may incorrectly predict\n",
+        "women will default on the credit loan. The system may unfairly allocate\n",
+        "less loans to women and over-allocate loans to men.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Types of harm experienced\n",
+        "=========================\n",
+        "\n",
+        "When discussing fairness in AI systems, the first step is understanding\n",
+        "what types of harms we anticipate the system may produce. Using the\n",
+        "`harms taxonomy in the Fairlearn User Guide <types_of_harms>`{.interpreted-text\n",
+        "role=\"ref\"}, we expect this system to produce *harms of allocation*. In\n",
+        "addition, we also anticipate the long-term impact on an individual\\'s\n",
+        "credit score if an individual is unable to repay a loan they receive or\n",
+        "if they are rejected for a loan application. A *harm of allocation*\n",
+        "occurs when an AI system extends or withholds resources, opportunities,\n",
+        "information. In this scenario, the AI system is extending or withholding\n",
+        "financial assets from individuals. A review of historical incidents\n",
+        "shows these types of automated lending decision systems may discriminate\n",
+        "unfairly based on sex.\n",
+        "\n",
+        "**Negative impact of credit score**\n",
+        "\n",
+        "A secondary harm that is somewhat unique to credit lending decisions is\n",
+        "the long-term impact on an individual\\'s credit score. In the United\n",
+        "States, a [FICO credit\n",
+        "score](https://www.investopedia.com/terms/c/credit_score.asp) is a\n",
+        "number between 300 and 850 that represents a customer\\'s\n",
+        "*creditworthiness*. An applicant\\'s *credit score* is used by many\n",
+        "financial institutions for lending decisions. An applicant\\'s *credit\n",
+        "score* usually increases after a successful repayment of a loan and\n",
+        "decreases if the applicant fails to repay the loan.\n",
+        "\n",
+        "When applying for a credit loan, there are three major outcomes:\n",
+        "\n",
+        "1.  The individual receives the credit loan and pays back the loan. In\n",
+        "    this scenario, we expect the individual\\'s credit score to increase\n",
+        "    as a result of the successful repayment of the loan.\n",
+        "2.  The individual receives the credit loan but defaults on the loan. In\n",
+        "    this scenario, the individual\\'s credit score will drop drastically\n",
+        "    due to the failure to repay the loan. In the modeling process, this\n",
+        "    outcome is tied to a **false negative** (the model predicts the\n",
+        "    individual will repay the loan, but the individual is unsuccessful\n",
+        "    in doing so).\n",
+        "3.  In certain countries, such as the United States, an individual\n",
+        "    receives a small drop (up to five points) to their credit score\n",
+        "    after a lender performs a *hard inquiry* on the applicant\\'s credit\n",
+        "    history. If the applicant applies for a loan but does not receive\n",
+        "    it, the small decrease in their credit score will impact their\n",
+        "    ability to successfully apply for a future loan. In the modeling\n",
+        "    process, this outcome is tied to the **selection rate** (the\n",
+        "    proportion of positive predictions outputted by the model).\n",
+        "\n",
+        "**Prevention of wealth accumulation**\n",
+        "\n",
+        "One other type of harm we anticipate in this scenario is the long-term\n",
+        "effects of *denying loans to applicants who would have successfully paid\n",
+        "back the loan*. By receiving a loan, an applicant is able to purchase a\n",
+        "home, start a business, or pursue some other economic activity that they\n",
+        "are not able to do otherwise. These outcomes are tied to **false\n",
+        "positive error** rates in which the model predicts an applicant will\n",
+        "default on the loan, but the individual would have successfully paid the\n",
+        "loan back. In the United States, the practice of redlining\n",
+        "`peyton2020redlining`{.interpreted-text role=\"footcite\"}, denying\n",
+        "mortgage loans and other financial services to predominantly Black or\n",
+        "other minority communities, has resulted in a vast racial wealth gap\n",
+        "between white and Black Americans. Although the practice of redlining\n",
+        "was banned in 1968 with the *Fair Housing Act*, the long-term impact of\n",
+        "these practices `jan2018redlining`{.interpreted-text role=\"footcite\"} is\n",
+        "reflected in the lack of economic investment in Black communities, and\n",
+        "Black applicants are denied loans at a higher rate compared to white\n",
+        "Americans.\n",
+        "\n",
+        "Define fairness metrics based on harms\n",
+        "--------------------------------------\n",
+        "\n",
+        "Now that we have identified the relevant harms we anticipate users will\n",
+        "experience, we can define our fairness metrics. In addition to the\n",
+        "metrics, we will quantify the uncertainty around each metric using\n",
+        "*custom functions* to compute the *standard error* for each metric at\n",
+        "the $\\alpha=0.95$ confidence level.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "def compute_error_metric(metric_value, sample_size):\n",
+        "    \"\"\"Compute standard error of a given metric based on the assumption of\n",
+        "    normal distribution.\n",
+        "\n",
+        "    Parameters:\n",
+        "    metric_value: Value of the metric\n",
+        "    sample_size: Number of data points associated with the metric\n",
+        "\n",
+        "    Returns:\n",
+        "    The standard error of the metric\n",
+        "    \"\"\"\n",
+        "    metric_value = metric_value / sample_size\n",
+        "    return 1.96 * np.sqrt(metric_value * (1.0 - metric_value)) / np.sqrt(sample_size)\n",
+        "\n",
+        "\n",
+        "def false_positive_error(y_true, y_pred):\n",
+        "    \"\"\"Compute the standard error for the false positive rate estimate.\"\"\"\n",
+        "    tn, fp, fn, tp = confusion_matrix(y_true, y_pred).ravel()\n",
+        "    return compute_error_metric(fp, tn + fp)\n",
+        "\n",
+        "\n",
+        "def false_negative_error(y_true, y_pred):\n",
+        "    \"\"\"Compute the standard error for the false negative rate estimate.\"\"\"\n",
+        "    tn, fp, fn, tp = confusion_matrix(y_true, y_pred).ravel()\n",
+        "    return compute_error_metric(fn, fn + tp)\n",
+        "\n",
+        "\n",
+        "def balanced_accuracy_error(y_true, y_pred):\n",
+        "    \"\"\"Compute the standard error for the balanced accuracy estimate.\"\"\"\n",
+        "    fpr_error, fnr_error = false_positive_error(y_true, y_pred), false_negative_error(\n",
+        "        y_true, y_pred\n",
+        "    )\n",
+        "    return np.sqrt(fnr_error**2 + fpr_error**2) / 2\n",
+        "\n",
+        "\n",
+        "fairness_metrics = {\n",
+        "    \"count\": count,\n",
+        "    \"balanced_accuracy\": balanced_accuracy_score,\n",
+        "    \"balanced_acc_error\": balanced_accuracy_error,\n",
+        "    \"selection_rate\": selection_rate,\n",
+        "    \"false_positive_rate\": false_positive_rate,\n",
+        "    \"false_positive_error\": false_positive_error,\n",
+        "    \"false_negative_rate\": false_negative_rate,\n",
+        "    \"false_negative_error\": false_negative_error,\n",
+        "}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Select a subset of metrics to report to avoid information overload\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "metrics_to_report = [\n",
+        "    \"balanced_accuracy\",\n",
+        "    \"false_positive_rate\",\n",
+        "    \"false_negative_rate\",\n",
+        "]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "To compute the disaggregated performance metrics, we will use the\n",
+        "`MetricFrame` object within the Fairlearn library. We will pass in our\n",
+        "dictionary of metrics `fairness_metrics`, along with our test labels\n",
+        "`y_test` and test predictions `Y_pred`. In addition, we pass in the\n",
+        "*sensitive\\_features* `A_test` to disaggregate our model results.\n",
+        "\n",
+        "Instantiate the MetricFrame for the unmitigated model\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "metricframe_unmitigated = MetricFrame(\n",
+        "    metrics=fairness_metrics,\n",
+        "    y_true=y_test,\n",
+        "    y_pred=Y_pred,\n",
+        "    sensitive_features=A_test,\n",
+        ")\n",
+        "\n",
+        "metricframe_unmitigated.by_group[metrics_to_report]\n",
+        "\n",
+        "metricframe_unmitigated.difference()[metrics_to_report]\n",
+        "\n",
+        "metricframe_unmitigated.overall[metrics_to_report]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "def plot_group_metrics_with_error_bars(metricframe, metric, error_name):\n",
+        "    \"\"\"Plot the disaggregated metric for each group with an associated\n",
+        "    error bar. Both metric and the error bar are provided as columns in the\n",
+        "    provided MetricFrame.\n",
+        "\n",
+        "    Parameters\n",
+        "    ----------\n",
+        "    metricframe : MetricFrame\n",
+        "        The MetricFrame containing the metrics and their associated\n",
+        "        uncertainty quantification.\n",
+        "    metric : str\n",
+        "        The metric to plot\n",
+        "    error_name : str\n",
+        "        The associated standard error for each metric in metric\n",
+        "\n",
+        "    Returns\n",
+        "    -------\n",
+        "    Matplotlib Plot of point estimates with error bars\n",
+        "    \"\"\"\n",
+        "    grouped_metrics = metricframe.by_group\n",
+        "    point_estimates = grouped_metrics[metric]\n",
+        "    error_bars = grouped_metrics[error_name]\n",
+        "    lower_bounds = point_estimates - error_bars\n",
+        "    upper_bounds = point_estimates + error_bars\n",
+        "\n",
+        "    x_axis_names = [str(name) for name in error_bars.index.to_flat_index().tolist()]\n",
+        "    plt.vlines(\n",
+        "        x_axis_names,\n",
+        "        lower_bounds,\n",
+        "        upper_bounds,\n",
+        "        linestyles=\"dashed\",\n",
+        "        alpha=0.45,\n",
+        "    )\n",
+        "    plt.scatter(x_axis_names, point_estimates, s=25)\n",
+        "    plt.xticks(rotation=0)\n",
+        "    y_start, y_end = np.round(min(lower_bounds), decimals=2), np.round(\n",
+        "        max(upper_bounds), decimals=2\n",
+        "    )\n",
+        "    plt.yticks(np.arange(y_start, y_end, 0.05))\n",
+        "    plt.ylabel(metric)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "plot_group_metrics_with_error_bars(\n",
+        "    metricframe_unmitigated, \"false_positive_rate\", \"false_positive_error\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "plot_group_metrics_with_error_bars(\n",
+        "    metricframe_unmitigated, \"false_negative_rate\", \"false_negative_error\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "metricframe_unmitigated.by_group[metrics_to_report].plot.bar(\n",
+        "    subplots=True, layout=[1, 3], figsize=[12, 4], legend=None, rot=0\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Finally, let\\'s compute the `equalized_odds_difference` for this\n",
+        "unmitigated model. The `equalized_odds_difference` is the maximum of the\n",
+        "`false_positive_rate_difference` and `false_negative_rate_difference`.\n",
+        "In our lending context, both *false\\_negative\\_rate\\_disparities* and\n",
+        "*false\\_positive\\_rate\\_disparities* result in fairness-related harms.\n",
+        "Therefore, we attempt to minimize both of these metrics by minimizing\n",
+        "the `equalized_odds_difference`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "balanced_accuracy_unmitigated = balanced_accuracy_score(y_test, Y_pred)\n",
+        "equalized_odds_unmitigated = equalized_odds_difference(y_test, Y_pred, sensitive_features=A_test)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "One key assumption here is we assume that *false positives* and *false\n",
+        "negatives* have the equally adverse costs to each group. In practice, we\n",
+        "would develop some weighting mechanism to assign a weight to each *false\n",
+        "negative* and *false positive* event.\n",
+        "\n",
+        "Mitigating Unfairness in ML models\n",
+        "==================================\n",
+        "\n",
+        "In the previous section, we identified disparities in the model\\'s\n",
+        "performance with respect to `SEX`. In particular, we found that model\n",
+        "produces a significantly higher `false_negative_rate` and\n",
+        "`false_positive_rate` for the applicants labeled `female` compared to\n",
+        "those labeled `male`. In the context of credit decision scenario, this\n",
+        "means the model under-allocates loans to *women* who would have paid the\n",
+        "loan, but over-allocates loans to *women* who go on to default on their\n",
+        "loan.\n",
+        "\n",
+        "In this section, we will discuss strategies for mitigating the\n",
+        "performance disparities we found in our unmitigated model. We will apply\n",
+        "two different mitigation strategies:\n",
+        "\n",
+        "-   *Postprocessing*: In the postprocessing approach, the outputs of a\n",
+        "    trained classifier are transformed to satisfy some fairness\n",
+        "    criterion.\n",
+        "-   *Reductions*: In the reductions approach, we take in a model class\n",
+        "    and iteratively create a sequence of models that optimize some\n",
+        "    fairness constraint. Compared to the *postprocessing* approach, the\n",
+        "    fairness constraint is satisfied during the model training time\n",
+        "    rather than afterwards.\n",
+        "\n",
+        "Postprocessing mitigations: ThresholdOptimizer\n",
+        "----------------------------------------------\n",
+        "\n",
+        "In the Fairlearn package, *postprocessing* mitigation is offered through\n",
+        "the `ThresholdOptimizer` algorithm, following\n",
+        ":footcite`hardt2016equality`{.interpreted-text role=\"cts\"}. The\n",
+        "`ThresholdOptimizer` takes in an existing (possibly pre-fit) machine\n",
+        "learning model whose predictions acts as a scoring function to identify\n",
+        "separate thresholds for each *sensitive feature* group. The\n",
+        "`ThresholdOptimizer` optimizes a specified objective metric (in our\n",
+        "case, `balanced_accuracy`) subject to some fairness constraint\n",
+        "([equalized\\_odds]{.title-ref}), resulting in a thresholded version of\n",
+        "the underlying machine learning model.\n",
+        "\n",
+        "To instantiate our `ThresholdOptimizer`, we need to specify our fairness\n",
+        "constraint as a model parameter. Because both `false_negative_rate`\n",
+        "disparities and `false_positive_rate` disparities translate into\n",
+        "real-world harms in our scenario, we will aim to minimize the\n",
+        "`equalized_odds` difference as our *fairness constraint*.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "postprocess_est = ThresholdOptimizer(\n",
+        "    estimator=estimator,\n",
+        "    constraints=\"equalized_odds\",  # Optimize FPR and FNR simultaneously\n",
+        "    objective=\"balanced_accuracy_score\",\n",
+        "    prefit=True,\n",
+        "    predict_method=\"predict_proba\",\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "One key limitation of the `ThresholdOptimizer` is the need for sensitive\n",
+        "features during training and prediction time. If we do not have access\n",
+        "to the `sensitive_features` during prediction time, we cannot use the\n",
+        "`ThresholdOptimizer`.\n",
+        "\n",
+        "We pass in `A_train` to the `fit` function with the `sensitive_features`\n",
+        "parameter.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "postprocess_est.fit(X=X_train, y=y_train, sensitive_features=A_train)\n",
+        "\n",
+        "postprocess_pred = postprocess_est.predict(X_test, sensitive_features=A_test)\n",
+        "\n",
+        "postprocess_pred_proba = postprocess_est._pmf_predict(X_test, sensitive_features=A_test)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Fairness assessment of postprocessing model\n",
+        "===========================================\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "def compare_metricframe_results(mframe_1, mframe_2, metrics, names):\n",
+        "    \"\"\"Concatenate the results of two MetricFrames along a subset of metrics.\n",
+        "\n",
+        "    Parameters\n",
+        "    ----------\n",
+        "    mframe_1: First MetricFrame for comparison\n",
+        "    mframe_2: Second MetricFrame for comparison\n",
+        "    metrics: The subset of metrics for comparison\n",
+        "    names: The names of the selected metrics\n",
+        "\n",
+        "    Returns\n",
+        "    -------\n",
+        "    MetricFrame : MetricFrame\n",
+        "        The concatenation of the two MetricFrames, restricted to the metrics\n",
+        "        specified.\n",
+        "\n",
+        "    \"\"\"\n",
+        "    return pd.concat(\n",
+        "        [mframe_1.by_group[metrics], mframe_2.by_group[metrics]],\n",
+        "        keys=names,\n",
+        "        axis=1,\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "bal_acc_postprocess = balanced_accuracy_score(y_test, postprocess_pred)\n",
+        "eq_odds_postprocess = equalized_odds_difference(\n",
+        "    y_test, postprocess_pred, sensitive_features=A_test\n",
+        ")\n",
+        "\n",
+        "metricframe_postprocess = MetricFrame(\n",
+        "    metrics=fairness_metrics,\n",
+        "    y_true=y_test,\n",
+        "    y_pred=postprocess_pred,\n",
+        "    sensitive_features=A_test,\n",
+        ")\n",
+        "\n",
+        "metricframe_postprocess.overall[metrics_to_report]\n",
+        "\n",
+        "metricframe_postprocess.difference()[metrics_to_report]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Now, let\\'s compare the performance of our *thresholded* classifier with\n",
+        "the original *unmitigated* model.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "compare_metricframe_results(\n",
+        "    metricframe_unmitigated,\n",
+        "    metricframe_postprocess,\n",
+        "    metrics=metrics_to_report,\n",
+        "    names=[\"Unmitigated\", \"PostProcess\"],\n",
+        ")\n",
+        "\n",
+        "metricframe_postprocess.by_group[metrics_to_report].plot.bar(\n",
+        "    subplots=True, layout=[1, 3], figsize=[12, 4], legend=None, rot=0\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We see that the `ThresholdOptimizer` algorithm achieves a much lower\n",
+        "disparity between the two groups compared to the *unmitigated* model.\n",
+        "However, this does come with the trade-off that the `ThresholdOptimizer`\n",
+        "achieves a lower `balanced_accuracy` score for *male* applicants.\n",
+        "\n",
+        "Reductions approach to unfairness mitigation\n",
+        "============================================\n",
+        "\n",
+        "In the previous section, we took a fairness-unaware model and used the\n",
+        "`ThresholdOptimizer` to transform the model\\'s decision boundary to\n",
+        "satisfy our fairness constraints. One key limitation of the\n",
+        "`ThresholdOptimizer` is needing access to our *sensitive\\_feature*\n",
+        "during prediction time.\n",
+        "\n",
+        "In this section, we will use the *reductions* approach of Agarwal et. al\n",
+        "(2018) `agarwal2018reductions`{.interpreted-text role=\"footcite\"} to\n",
+        "produce models that satisfy the fairness constraint without needing\n",
+        "access to the sensitive features at deployment time.\n",
+        "\n",
+        "The main reduction algorithm in Fairlearn is `ExponentiatedGradient`.\n",
+        "The algorithm creates a sequence of re-weighted datasets and retrains\n",
+        "the wrapped classifier on each of the datasets. This re-training process\n",
+        "is guaranteed to find a model that satisfies the fairness constraints\n",
+        "while optimizing the performance metric.\n",
+        "\n",
+        "The model returned by `ExponentiatedGradient` consists of several inner\n",
+        "models, returned by a wrapped estimator.\n",
+        "\n",
+        "To instantiate an `ExponentiatedGradient` model, we pass in two\n",
+        "parameters:\n",
+        "\n",
+        "-   a base `estimator` (object that supports training)\n",
+        "-   fairness `constraints` (object of type\n",
+        "    `fairlearn.reductions.Moment`{.interpreted-text role=\"class\"})\n",
+        "\n",
+        "When passing in a fairness *constraint* as a `Moment`, we can specify an\n",
+        "`epsilon` value representing the maximum allowed difference or ratio\n",
+        "between our largest and smallest value. For example, in the below code,\n",
+        "`EqualizedOdds(difference_bound=epsilon)` means that we are using\n",
+        "`EqualizedOdds` as our fairness constraint, and we will allow a maximal\n",
+        "difference of `epsilon` between our largest and smallest *equalized\n",
+        "odds* value.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "def get_expgrad_models_per_epsilon(estimator, epsilon, X_train, y_train, A_train):\n",
+        "    \"\"\"Instantiate and train an ExponentiatedGradient model on the\n",
+        "    balanced training dataset.\n",
+        "\n",
+        "    Parameters\n",
+        "    ----------\n",
+        "    Estimator: Base estimator to contains a fit and predict function.\n",
+        "    Epsilon: Float representing maximum difference bound for the fairness Moment constraint\n",
+        "\n",
+        "    Returns\n",
+        "    -------\n",
+        "    Predictors\n",
+        "        List of inner model predictors learned by the ExponentiatedGradient\n",
+        "        model during the training process.\n",
+        "\n",
+        "    \"\"\"\n",
+        "    exp_grad_est = ExponentiatedGradient(\n",
+        "        estimator=estimator,\n",
+        "        sample_weight_name=\"classifier__sample_weight\",\n",
+        "        constraints=EqualizedOdds(difference_bound=epsilon),\n",
+        "    )\n",
+        "    # Is this an issue - Re-runs\n",
+        "    exp_grad_est.fit(X_train, y_train, sensitive_features=A_train)\n",
+        "    predictors = exp_grad_est.predictors_\n",
+        "    return predictors"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Because the *performance-fairness trade-off* learned by the\n",
+        "`ExponentiatedGradient` model is sensitive to our chosen `epsilon`\n",
+        "value, we can treat `epsilon` as a *hyperparameter* and iterate over a\n",
+        "range of potential values. Here, we will train two\n",
+        "`ExponentiatedGradient` models, one with `epsilon=0.01` and the second\n",
+        "with `epsilon=0.02`, and store the inner models learned through each of\n",
+        "the training processes.\n",
+        "\n",
+        "In practice, we recommend choosing smaller values of `epsilon` on the\n",
+        "order of the *square root* of the number of samples in the training\n",
+        "dataset:\n",
+        "$\\dfrac{1}{\\sqrt{\\text{numberSamples}}} \\approx \\dfrac{1}{\\sqrt{25000}} \\approx 0.01$\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "epsilons = [0.01, 0.02]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "all_models = {}\n",
+        "for eps in epsilons:\n",
+        "    all_models[eps] = get_expgrad_models_per_epsilon(\n",
+        "        estimator=estimator,\n",
+        "        epsilon=eps,\n",
+        "        X_train=X_train,\n",
+        "        y_train=y_train,\n",
+        "        A_train=A_train,\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "for epsilon, models in all_models.items():\n",
+        "    print(f\"For epsilon {epsilon}, ExponentiatedGradient learned {len(models)} inner models\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Here, we can see all the inner models learned for each value of\n",
+        "`epsilon`. With the `ExponentiatedGradient` model, we specify an\n",
+        "`epsilon` parameter that represents the maximal disparity in our\n",
+        "fairness metric that our final model should satisfy. For example, an\n",
+        "`epsilon=0.02` means that the training value of the *equalized odds\n",
+        "difference* of the returned model is at most `0.02` (if the algorithm\n",
+        "converges).\n",
+        "\n",
+        "Reviewing inner models of ExponentiatedGradient\n",
+        "===============================================\n",
+        "\n",
+        "In many situations due to regulation or other technical restrictions,\n",
+        "the randomized nature of `ExponentiatedGradient` algorithm may be\n",
+        "undesirable. In addition, the multiple inner models of the algorithm\n",
+        "introduce challenges for model interpretability. One potential\n",
+        "workaround to avoid these issues is to select one of the inner models\n",
+        "and deploy it instead.\n",
+        "\n",
+        "In the previous section, we trained multiple `ExponentiatedGradient`\n",
+        "models at different `epsilon` levels and collected all the inner models\n",
+        "learned by this process. When picking a suitable inner model, we\n",
+        "consider trade-offs between our two metrics of interest: *balanced error\n",
+        "rate* and *equalized odds difference*. Since our focus is on these two\n",
+        "metrics, we will filter out the models that are outperformed in both of\n",
+        "the metrics by some other model (we refer to these as *\\\"dominated\\\"*\n",
+        "models), and plot just the remaining *\\\"undominated\\\"* models.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "def is_pareto_efficient(points):\n",
+        "    \"\"\"Filter a NumPy Matrix to remove rows that are strictly dominated by\n",
+        "    another row in the matrix. Strictly dominated means the all the row values\n",
+        "    are greater than the values of another row.\n",
+        "\n",
+        "    Parameters\n",
+        "    ----------\n",
+        "    Points: NumPy array (NxM) of model metrics.\n",
+        "        Assumption that smaller values for metrics are preferred.\n",
+        "\n",
+        "    Returns\n",
+        "    -------\n",
+        "    Boolean Array\n",
+        "        Nx1 boolean mask representing the non-dominated indices.\n",
+        "    \"\"\"\n",
+        "    n, m = points.shape\n",
+        "    is_efficient = np.ones(n, dtype=bool)\n",
+        "    for i, c in enumerate(points):\n",
+        "        if is_efficient[i]:\n",
+        "            is_efficient[is_efficient] = np.any(points[is_efficient] < c, axis=1)\n",
+        "            is_efficient[i] = True\n",
+        "    return is_efficient"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "def filter_dominated_rows(points):\n",
+        "    \"\"\"Remove rows from a DataFrame that are monotonically dominated by\n",
+        "    another row in the DataFrame.\n",
+        "\n",
+        "    Parameters\n",
+        "    ----------\n",
+        "    Points: DataFrame where each row represents the summarized performance\n",
+        "            (balanced accuracy, fairness metric) of an inner model.\n",
+        "\n",
+        "    Returns\n",
+        "    -------\n",
+        "    pareto mask: Boolean mask representing indices of input DataFrame that are not monotonically dominated.\n",
+        "    masked_DataFrame: DataFrame with dominated rows filtered out.\n",
+        "\n",
+        "    \"\"\"\n",
+        "    pareto_mask = is_pareto_efficient(points.to_numpy())\n",
+        "    return pareto_mask, points.loc[pareto_mask, :]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "def aggregate_predictor_performances(predictors, metric, X_test, Y_test, A_test=None):\n",
+        "    \"\"\"Compute the specified metric for all classifiers in predictors.\n",
+        "    If no sensitive features are present, the metric is computed without\n",
+        "    disaggregation.\n",
+        "\n",
+        "    Parameters\n",
+        "    ----------\n",
+        "    predictors: A set of classifiers to generate predictions from.\n",
+        "    metric: The metric (callable) to compute for each classifier in predictor\n",
+        "    X_test: The data features of the testing data set\n",
+        "    Y_test: The target labels of the teting data set\n",
+        "    A_test: The sensitive feature of the testing data set.\n",
+        "\n",
+        "    Returns\n",
+        "    -------\n",
+        "    List of performance scores for each classifier in predictors, for the\n",
+        "    given metric.\n",
+        "    \"\"\"\n",
+        "    all_predictions = [predictor.predict(X_test) for predictor in predictors]\n",
+        "    if A_test is not None:\n",
+        "        return [metric(Y_test, Y_sweep, sensitive_features=A_test) for Y_sweep in all_predictions]\n",
+        "    else:\n",
+        "        return [metric(Y_test, Y_sweep) for Y_sweep in all_predictions]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "def model_performance_sweep(models_dict, X_test, y_test, A_test):\n",
+        "    \"\"\"Compute the equalized_odds_difference and balanced_error_rate for a\n",
+        "    given list of inner models learned by the ExponentiatedGradient algorithm.\n",
+        "    Return a DataFrame containing the epsilon level of the model, the index\n",
+        "    of the model, the equalized_odds_difference score and the balanced_error\n",
+        "    for the model.\n",
+        "\n",
+        "    Parameters\n",
+        "    ----------\n",
+        "    models_dict: Dictionary mapping model ids to a model.\n",
+        "    X_test: The data features of the testing data set\n",
+        "    y_test: The target labels of the testing data set\n",
+        "    A_test: The sensitive feature of the testing data set.\n",
+        "\n",
+        "    Returns\n",
+        "    -------\n",
+        "    DataFrame where each row represents a model (epsilon, index) and its\n",
+        "    performance metrics\n",
+        "    \"\"\"\n",
+        "    performances = []\n",
+        "    for eps, models in models_dict.items():\n",
+        "        eq_odds_difference = aggregate_predictor_performances(\n",
+        "            models, equalized_odds_difference, X_test, y_test, A_test\n",
+        "        )\n",
+        "        bal_acc_score = aggregate_predictor_performances(\n",
+        "            models, balanced_accuracy_score, X_test, y_test\n",
+        "        )\n",
+        "        for i, score in enumerate(eq_odds_difference):\n",
+        "            performances.append((eps, i, score, (1 - bal_acc_score[i])))\n",
+        "    performances_df = pd.DataFrame.from_records(\n",
+        "        performances,\n",
+        "        columns=[\"epsilon\", \"index\", \"equalized_odds\", \"balanced_error\"],\n",
+        "    )\n",
+        "    return performances_df"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "performance_df = model_performance_sweep(all_models, X_test, y_test, A_test)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "performance_subset = performance_df.loc[:, [\"equalized_odds\", \"balanced_error\"]]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "mask, pareto_subset = filter_dominated_rows(performance_subset)\n",
+        "\n",
+        "performance_df_masked = performance_df.loc[mask, :]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Now, let\\'s plot the performance trade-offs between all of our models.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "for index, row in performance_df_masked.iterrows():\n",
+        "    bal_error, eq_odds_diff = row[\"balanced_error\"], row[\"equalized_odds\"]\n",
+        "    epsilon_, index_ = row[\"epsilon\"], row[\"index\"]\n",
+        "    plt.scatter(bal_error, eq_odds_diff, color=\"green\", label=\"ExponentiatedGradient\")\n",
+        "    plt.text(\n",
+        "        bal_error + 0.001,\n",
+        "        eq_odds_diff + 0.0001,\n",
+        "        f\"Eps: {epsilon_}, Idx: {int(index_)}\",\n",
+        "        fontsize=10,\n",
+        "    )\n",
+        "plt.scatter(\n",
+        "    1.0 - balanced_accuracy_unmitigated,\n",
+        "    equalized_odds_unmitigated,\n",
+        "    label=\"UnmitigatedModel\",\n",
+        ")\n",
+        "plt.scatter(1.0 - bal_acc_postprocess, eq_odds_postprocess, label=\"PostProcess\")\n",
+        "plt.xlabel(\"Weighted Error Rate\")\n",
+        "plt.ylabel(\"Equalized Odds\")\n",
+        "plt.legend(bbox_to_anchor=(1.85, 1))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "With the above plot, we can see how the performance of the non-dominated\n",
+        "inner models compares to the original unmitigated model. In many cases,\n",
+        "we see that a reduction in the `equalized_odds_difference` is\n",
+        "accompanied by a small increase in the *weighted error rate*.\n",
+        "\n",
+        "Selecting a suitable inner model\n",
+        "================================\n",
+        "\n",
+        "One strategy we can use to select a model is creating a *threshold*\n",
+        "based on the *balanced error rate* of the unmitigated model. Then out of\n",
+        "the filtered models, we select the model that minimizes the\n",
+        "`equalized_odds_difference`. The process can be broken down into the\n",
+        "three steps below:\n",
+        "\n",
+        "1.  Create threshold based on `balanced_error` of the unmitigated model.\n",
+        "2.  Filter only models whose `balanced_error` are below the threshold.\n",
+        "3.  Choose the model with smallest `equalized_odds` difference.\n",
+        "\n",
+        "Within the context of fair lending in the United States, if a financial\n",
+        "institution is found to be engaging in discriminatory behavior, they\n",
+        "must produce documentation that demonstrates the model chosen is the\n",
+        "least discriminatory model while satisfying profitability and other\n",
+        "business needs. In our approach, the business need of profitability is\n",
+        "simulated by thresholding based on the `balanced_error` rate of the\n",
+        "unmitigated model, and we choose the least discriminatory model based on\n",
+        "the smallest `equalized_odds_difference` value.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "def filter_models_by_unmitigiated_score(\n",
+        "    all_models,\n",
+        "    models_frames,\n",
+        "    unmitigated_score,\n",
+        "    performance_metric=\"balanced_error\",\n",
+        "    fairness_metric=\"equalized_odds\",\n",
+        "    threshold=0.01,\n",
+        "):\n",
+        "    \"\"\"Filter out models whose performance score is above the desired\n",
+        "    threshold. Out of the remaining model, return the models with the best\n",
+        "    score on the fairness metric.\n",
+        "\n",
+        "    Parameters\n",
+        "    ----------\n",
+        "    all_models: Dictionary (Epsilon, Index) mapping (epilson, index number) pairs to a Model object\n",
+        "    models_frames: A DataFrame representing each model's performance and fairness score.\n",
+        "    unmitigated_score: The performance score of the unmitigated model.\n",
+        "    performance_metric: The model performance metric to threshold on.\n",
+        "    fairness_metric: The fairness metric to optimize for\n",
+        "    threshold: The threshold padding added to the :code:`unmitigated_score`.\n",
+        "\n",
+        "    \"\"\"\n",
+        "    # Create threshold based on balanced_error of unmitigated model and filter\n",
+        "    models_filtered = models_frames.query(\n",
+        "        f\"{performance_metric} <= {unmitigated_score + threshold}\"\n",
+        "    )\n",
+        "    best_row = models_filtered.sort_values(by=[fairness_metric]).iloc[0]\n",
+        "    # Choose the model with smallest equalized_odds difference\n",
+        "    epsilon, index = best_row[[\"epsilon\", \"index\"]]\n",
+        "    return {\n",
+        "        \"model\": all_models[epsilon][index],\n",
+        "        \"epsilon\": epsilon,\n",
+        "        \"index\": index,\n",
+        "    }"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "best_model = filter_models_by_unmitigiated_score(\n",
+        "    all_models,\n",
+        "    models_frames=performance_df,\n",
+        "    unmitigated_score=(1.0 - balanced_accuracy_unmitigated),\n",
+        "    threshold=0.015,\n",
+        ")\n",
+        "\n",
+        "print(\n",
+        "    f\"Epsilon for best model: {best_model.get('epsilon')}, Index number: {best_model.get('index')}\"\n",
+        ")\n",
+        "inprocess_model = best_model.get(\"model\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Now we have selected our best inner model, let\\'s collect the model\\'s\n",
+        "predictions on the test dataset and compute the relevant performance\n",
+        "metrics.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "y_pred_inprocess = inprocess_model.predict(X_test)\n",
+        "\n",
+        "bal_acc_inprocess = balanced_accuracy_score(y_test, y_pred_inprocess)\n",
+        "eq_odds_inprocess = equalized_odds_difference(y_test, y_pred_inprocess, sensitive_features=A_test)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "metricframe_inprocess = MetricFrame(\n",
+        "    metrics=fairness_metrics,\n",
+        "    y_true=y_test,\n",
+        "    y_pred=y_pred_inprocess,\n",
+        "    sensitive_features=A_test,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "metricframe_inprocess.difference()[metrics_to_report]\n",
+        "\n",
+        "metricframe_inprocess.overall[metrics_to_report]\n",
+        "\n",
+        "metricframe_inprocess.by_group[metrics_to_report].plot.bar(\n",
+        "    subplots=True, layout=[1, 3], figsize=[12, 4], legend=None, rot=0\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Discuss Performance and Trade-Offs\n",
+        "==================================\n",
+        "\n",
+        "Now we have trained two different fairness-aware models using the\n",
+        "*postprocessing* approach and the *reductions* approach. Let\\'s compare\n",
+        "the performance of these models to our original fairness-unaware model.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "metric_error_pairs = [\n",
+        "    (\"balanced_accuracy\", \"balanced_acc_error\"),\n",
+        "    (\"false_positive_rate\", \"false_positive_error\"),\n",
+        "    (\"false_negative_rate\", \"false_negative_error\"),\n",
+        "]\n",
+        "\n",
+        "\n",
+        "def create_metricframe_w_errors(mframe, metrics_to_report, metric_error_pair):\n",
+        "    mframe_by_group = mframe.by_group.copy()\n",
+        "    for metric_name, error_name in metric_error_pair:\n",
+        "        mframe_by_group[metric_name] = mframe_by_group[metric_name].apply(lambda x: f\"{x:.3f}\")\n",
+        "        mframe_by_group[error_name] = mframe_by_group[error_name].apply(lambda x: f\"{x:.3f}\")\n",
+        "        mframe_by_group[metric_name] = mframe_by_group[metric_name].str.cat(\n",
+        "            mframe_by_group[error_name], sep=\"±\"\n",
+        "        )\n",
+        "    return mframe_by_group[metrics_to_report]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Report model performance error bars for metrics\n",
+        "===============================================\n",
+        "\n",
+        "**Unmitigated model**\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "create_metricframe_w_errors(metricframe_unmitigated, metrics_to_report, metric_error_pairs)\n",
+        "\n",
+        "metricframe_unmitigated.overall[metrics_to_report]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**ExponentiatedGradient model**\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "create_metricframe_w_errors(metricframe_inprocess, metrics_to_report, metric_error_pairs)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**ThresholdOptimizer**\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "metricframe_inprocess.overall[metrics_to_report]\n",
+        "\n",
+        "create_metricframe_w_errors(metricframe_postprocess, metrics_to_report, metric_error_pairs)\n",
+        "\n",
+        "metricframe_postprocess.overall[metrics_to_report]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We see both of our fairness-aware models yield a slight decrease in the\n",
+        "*balanced\\_accuracy* for *male applicants* compared to our\n",
+        "fairness-unaware model. In the *reductions* model, we see a decrease in\n",
+        "the *false positive rate* for *female applicants*. This is accompanied\n",
+        "by an increase in the *false negative rate* for *male applicants*.\n",
+        "However overall, the *equalized odds difference* for the *reductions*\n",
+        "models is lower than that of the original fairness-unaware model.\n",
+        "\n",
+        "Conclusion and Discussion\n",
+        "=========================\n",
+        "\n",
+        "In this case study, we walked through the process of assessing a credit\n",
+        "decision model for gender-related performance disparities. Our analysis\n",
+        "follows closely the work done in the Microsoft/EY white paper\n",
+        "`dudik2020assessing`{.interpreted-text role=\"footcite\"} where they used\n",
+        "the *Fairlearn* toolkit to perform an audit of a fairness-unaware\n",
+        "tree-based model. We applied a *postprocessing* and *reductions*\n",
+        "mitigation techniques to mitigate the *equalized odds difference* in our\n",
+        "model.\n",
+        "\n",
+        "Through the *reductions* process, we generated a model that reduces the\n",
+        "*equalized odds difference* of the original model without a drastic\n",
+        "increase in the *balanced error score*. If this were a real model being\n",
+        "developed a financial institution, the *balanced error score* would be a\n",
+        "proxy for the profitability of the model. By maintaining a relatively\n",
+        "similar *balanced error score*, we\\'ve produced a model that preserves\n",
+        "profitability to the firm while producing more fair and equitable\n",
+        "outcomes for women in this scenario.\n",
+        "\n",
+        "Designing a Model Card\n",
+        "----------------------\n",
+        "\n",
+        "A key facet of Responsible Machine Learning is responsible documentation\n",
+        "practices. :footcite`mitchell2019model`{.interpreted-text role=\"ct\"}\n",
+        "proposed the model card framework for documentating and reporting model\n",
+        "training details and deployment considerations.\n",
+        "\n",
+        "A *model card* contains sections for documenting training and evaluation\n",
+        "dataset descriptions, ethical concerns, and quantitative evaluation\n",
+        "summaries. In practice, we would ideally create a model card for our\n",
+        "model before deploying it in production. Although we will not be\n",
+        "producing a model card in this case study, interested readers can learn\n",
+        "more about creating model cards using the *Model Card Toolkit* from the\n",
+        "[Fairlearn PyCon\n",
+        "tutorial](https://github.com/fairlearn/talks/tree/main/2022_pycon).\n",
+        "\n",
+        "Fairness under unawareness\n",
+        "--------------------------\n",
+        "\n",
+        "When proving credit models are compliant with fair lending laws,\n",
+        "practitoners may run into the issue of not having access to the\n",
+        "sensitive demographic features. As a result, financial institutions are\n",
+        "often tasked with proving their models are compliant with fair lending\n",
+        "laws by imputing these demographics features. However,\n",
+        ":footcite`chen2019fairness`{.interpreted-text role=\"ct\"} show these\n",
+        "imputation methods often introduce new fairness-related issues.\n",
+        "\n",
+        "References\n",
+        "==========\n",
+        "\n",
+        "::: {.footbibliography}\n",
+        ":::\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
This pull request adds a draft of the tutorial on designing fair machine learning algorithms at an advanced level. It includes the following files:

README_fairness.md: An introduction and overview of fairness in machine learning algorithms.

default of credit card clients.xls: A dataset used for credit loan decisions to explore fairness.

plot_credit_loan_decisions.ipynb: A Jupyter notebook that demonstrates how to plot and analyze credit loan decisions with respect to fairness.

This tutorial is aimed at educating users on how to design fair machine learning algorithms by providing practical examples and hands-on exercises. The content is tailored for an advanced-level audience.