### PR TITLE
word embedding tutorial review

### DIFF
--- a/NLP textual data and word embeddings/Session2_Contextual_Embeddings.ipynb
+++ b/NLP textual data and word embeddings/Session2_Contextual_Embeddings.ipynb
@@ -179,11 +179,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "62a40d65-1829-477e-9c25-429e173ca965",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# import numpy as np\n",
     "def sentence_embedding_w2v(sentence):\n",
     "    words = sentence.lower().split()\n",
     "    valid_words = [word for word in words if word in word2vec]\n",
@@ -194,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "cdf36e6c-75ac-4e40-84da-0a447abe030e",
    "metadata": {},
    "outputs": [
@@ -210,6 +211,8 @@
     }
    ],
    "source": [
+    "# from sklearn.metrics.pairwise import cosine_similarity\n",
+    "\n",
     "# Compute similarity scores for Word2Vec\n",
     "w2v_scores = []\n",
     "for row in dataset:\n",


### PR DESCRIPTION
Hello  @Lexo7  👋, thanks for the great work on this!

Just a couple of small notes:

* **Embedding method note**: You’re currently using the `[CLS]` token to represent BERT sentence embeddings. While this is common, many recent works suggest that mean pooling over all token embeddings tends to yield better results for semantic similarity tasks. It might be worth testing this alternative.

* **Evaluation suggestion**: To make the comparison between GloVe and BERT embeddings more robust, you could compute a correlation metric (like Pearson or Spearman) against the gold similarity scores from the STS dataset. This would complement the visual plot with a quantitative measure.

* **Missing imports**: (I've included the comment in the notebook)

  ```python
  import numpy as np
  from sklearn.metrics.pairwise import cosine_similarity
  ```

Let me know what you think happy to chat more or help clarify if needed!
